### PR TITLE
Force inlining of metric functions even with -O0

### DIFF
--- a/include/correct/convolutional/metric.h
+++ b/include/correct/convolutional/metric.h
@@ -1,5 +1,11 @@
 #include "correct/convolutional.h"
 
+// force inlining regardless of optimization settings
+#ifdef __GNUC__
+inline distance_t metric_distance(unsigned int x, unsigned int y) __attribute__((always_inline));
+inline distance_t metric_soft_distance_linear(unsigned int hard_x, const uint8_t *soft_y, size_t len) __attribute__((always_inline));
+#endif
+
 // measure the hamming distance of two bit strings
 // implemented as population count of x XOR y
 inline distance_t metric_distance(unsigned int x, unsigned int y) {


### PR DESCRIPTION
This is necessary to compile in debug mode on a machine without SSE (`-DCMAKE_BUILD_TYPE=DEBUG`)