### PR TITLE
support RS in GF(2^k) for k <= 8

### DIFF
--- a/include/correct/reed-solomon.h
+++ b/include/correct/reed-solomon.h
@@ -24,8 +24,8 @@ typedef uint16_t field_operation_t;
 typedef struct {
     const field_element_t *exp;
     const field_logarithm_t *log;
-    const unsigned int field_size;
-    const unsigned int largest_element;
+    unsigned int field_size;
+    unsigned int largest_element;
 } field_t;
 
 typedef struct {

--- a/include/correct/reed-solomon.h
+++ b/include/correct/reed-solomon.h
@@ -24,6 +24,8 @@ typedef uint16_t field_operation_t;
 typedef struct {
     const field_element_t *exp;
     const field_logarithm_t *log;
+    const unsigned int field_size;
+    const unsigned int largest_element;
 } field_t;
 
 typedef struct {

--- a/include/correct/reed-solomon/field.h
+++ b/include/correct/reed-solomon/field.h
@@ -24,15 +24,23 @@ static inline field_element_t field_mul_log_element(field_t field, field_logarit
 }
 
 static inline field_t field_create(field_operation_t primitive_poly) {
-    // in GF(2^8)
+    unsigned int width = 0;
+    field_operation_t temp_poly = primitive_poly >> 1;
+    while (temp_poly) {
+        temp_poly >>= 1;
+        ++width;
+    }
+    const unsigned int field_size = (1 << width);
+    const unsigned int largest_element = field_size - 1;
+    // in GF(2^width)
     // log and exp
-    // bits are in GF(2), compute alpha^val in GF(2^8)
-    // exp should be of size 512 so that it can hold a "wraparound" which prevents some modulo ops
-    // log should be of size 256. no wraparound here, the indices into this table are field elements
-    field_element_t *exp = malloc(512 * sizeof(field_element_t));
-    field_logarithm_t *log = malloc(256 * sizeof(field_logarithm_t));
+    // bits are in GF(2), compute alpha^val in GF(2^width)
+    // exp should be of size 2 * 2^width so that it can hold a "wraparound" which prevents some modulo ops
+    // log should be of size 2^width. no wraparound here, the indices into this table are field elements
+    field_element_t *exp = malloc(2 * field_size * sizeof(field_element_t));
+    field_logarithm_t *log = malloc(field_size * sizeof(field_logarithm_t));
 
-    // assume alpha is a primitive element, p(x) (primitive_poly) irreducible in GF(2^8)
+    // assume alpha is a primitive element, p(x) (primitive_poly) irreducible in GF(2^width)
     // addition is xor
     // subtraction is addition (also xor)
     // e.g. x^5 + x^4 + x^4 + x^2 + 1 = x^5 + x^2 + 1
@@ -45,11 +53,11 @@ static inline field_t field_create(field_operation_t primitive_poly) {
     field_operation_t element = 1;
     exp[0] = (field_element_t)element;
     log[0] = (field_logarithm_t)0;  // really, it's undefined. we shouldn't ever access this
-    for (field_operation_t i = 1; i < 512; i++) {
+    for (field_operation_t i = 1; i < 2 * field_size; i++) {
         element = element * 2;
-        element = (element > 255) ? (element ^ primitive_poly) : element;
+        element = (element > largest_element) ? (element ^ primitive_poly) : element;
         exp[i] = (field_element_t)element;
-        if (i < 256) {
+        if (i <= largest_element) {
             log[element] = (field_logarithm_t)i;
         }
     }
@@ -57,6 +65,8 @@ static inline field_t field_create(field_operation_t primitive_poly) {
     field_t field;
     *(field_element_t **)&field.exp = exp;
     *(field_logarithm_t **)&field.log = log;
+    *(unsigned int *)&field.field_size = field_size;
+    *(unsigned int *)&field.largest_element = largest_element;
 
     return field;
 }
@@ -99,13 +109,13 @@ static inline field_element_t field_mul(field_t field, field_element_t l, field_
     // yep, get your slide rules out
     field_operation_t res = (field_operation_t)field.log[l] + (field_operation_t)field.log[r];
 
-    // if coeff exceeds 255, we would normally have to wrap it back around
-    // alpha^255 = 1; alpha^256 = alpha^255 * alpha^1 = alpha^1
+    // if coeff exceeds largest_element, we would normally have to wrap it back around
+    // alpha^largest_element = 1; alpha^(largest_element + 1) = alpha^largest_element * alpha^1 = alpha^1
     // however, we've constructed exponentiation table so that
     //   we can just directly lookup this result
-    // the result must be clamped to [0, 511]
-    // the greatest we can see at this step is alpha^255 * alpha^255
-    //   = alpha^510
+    // the result must be clamped to [0, (2 * largest_element) + 1]
+    // the greatest we can see at this step is alpha^largest_element * alpha^largest_element
+    //   = alpha^(2 * largest_element)
     return field.exp[res];
 }
 
@@ -122,9 +132,9 @@ static inline field_element_t field_div(field_t field, field_element_t l, field_
     // division as subtraction of logarithms
 
     // if rcoeff is larger, then log[l] - log[r] wraps under
-    // so, instead, always add 255. in some cases, we'll wrap over, but
-    // that's ok because the exp table runs up to 511.
-    field_operation_t res = (field_operation_t)255 + (field_operation_t)field.log[l] - (field_operation_t)field.log[r];
+    // so, instead, always add largest_element. in some cases, we'll wrap over, but
+    // that's ok because the exp table runs up to (2 * largest_element) + 1.
+    field_operation_t res = (field_operation_t)field.largest_element + (field_operation_t)field.log[l] - (field_operation_t)field.log[r];
     return field.exp[res];
 }
 
@@ -134,20 +144,20 @@ static inline field_logarithm_t field_mul_log(field_t field, field_logarithm_t l
     field_operation_t res = (field_operation_t)l + (field_operation_t)r;
 
     // because we arent using the table, the value we return must be a valid logarithm
-    // which we have decided must live in [0, 255] (they are 8-bit values)
+    // which we have decided must live in [0, largest_element]
     // ensuring this makes it so that multiple muls will not reach past the end of the
     // exp table whenever we finally convert back to an element
-    if (res > 255) {
-        return (field_logarithm_t)(res - 255);
+    if (res > field.largest_element) {
+        return (field_logarithm_t)(res - field.largest_element);
     }
     return (field_logarithm_t)res;
 }
 
 static inline field_logarithm_t field_div_log(field_t field, field_logarithm_t l, field_logarithm_t r) {
     // like field_mul_log, this performs field_div without going through a field_element_t
-    field_operation_t res = (field_operation_t)255 + (field_operation_t)l - (field_operation_t)r;
-    if (res > 255) {
-        return (field_logarithm_t)(res - 255);
+    field_operation_t res = (field_operation_t)field.largest_element + (field_operation_t)l - (field_operation_t)r;
+    if (res > field.largest_element) {
+        return (field_logarithm_t)(res - field.largest_element);
     }
     return (field_logarithm_t)res;
 }
@@ -158,9 +168,9 @@ static inline field_element_t field_pow(field_t field, field_element_t elem, int
     // but here we have an arbitrary coeff
     field_logarithm_t log = field.log[elem];
     int res_log = log * pow;
-    int mod = res_log % 255;
+    int mod = res_log % field.largest_element;
     if (mod < 0) {
-        mod += 255;
+        mod += field.largest_element;
     }
     return field.exp[mod];
 }

--- a/include/correct/reed-solomon/field.h
+++ b/include/correct/reed-solomon/field.h
@@ -65,8 +65,8 @@ static inline field_t field_create(field_operation_t primitive_poly) {
     field_t field;
     *(field_element_t **)&field.exp = exp;
     *(field_logarithm_t **)&field.log = log;
-    *(unsigned int *)&field.field_size = field_size;
-    *(unsigned int *)&field.largest_element = largest_element;
+    field.field_size = field_size;
+    field.largest_element = largest_element;
 
     return field;
 }

--- a/src/reed-solomon/encode.c
+++ b/src/reed-solomon/encode.c
@@ -10,7 +10,11 @@ ssize_t correct_reed_solomon_encode(correct_reed_solomon *rs, const uint8_t *msg
         // message goes from high order to low order but libcorrect polynomials go low to high
         // so we reverse on the way in and on the way out
         // we'd have to do a copy anyway so this reversal should be free
-        rs->encoded_polynomial.coeff[rs->encoded_polynomial.order - (i + pad_length)] = msg[i];
+        field_element_t element = msg[i];
+        if (msg[i] > rs->field.largest_element) {
+            return -1;
+        }
+        rs->encoded_polynomial.coeff[rs->encoded_polynomial.order - (i + pad_length)] = element;
     }
 
     // 0-fill the rest of the coefficients -- this length will always be > 0

--- a/src/reed-solomon/reed-solomon.c
+++ b/src/reed-solomon/reed-solomon.c
@@ -13,7 +13,7 @@ static polynomial_t reed_solomon_build_generator(field_t field, unsigned int nro
 
 correct_reed_solomon *correct_reed_solomon_create(field_operation_t primitive_polynomial, field_logarithm_t first_consecutive_root, field_logarithm_t generator_root_gap, size_t num_roots) {
     correct_reed_solomon *rs = calloc(1, sizeof(correct_reed_solomon));
-    rs->field = field_create(primitive_polynomial);
+    *(field_t*)&(rs->field) = field_create(primitive_polynomial);
 
     rs->block_length = rs->field.largest_element;
     rs->min_distance = num_roots;

--- a/src/reed-solomon/reed-solomon.c
+++ b/src/reed-solomon/reed-solomon.c
@@ -13,7 +13,7 @@ static polynomial_t reed_solomon_build_generator(field_t field, unsigned int nro
 
 correct_reed_solomon *correct_reed_solomon_create(field_operation_t primitive_polynomial, field_logarithm_t first_consecutive_root, field_logarithm_t generator_root_gap, size_t num_roots) {
     correct_reed_solomon *rs = calloc(1, sizeof(correct_reed_solomon));
-    *(field_t*)&(rs->field) = field_create(primitive_polynomial);
+    rs->field = field_create(primitive_polynomial);
 
     rs->block_length = rs->field.largest_element;
     rs->min_distance = num_roots;

--- a/tests/include/rs_tester.h
+++ b/tests/include/rs_tester.h
@@ -12,6 +12,7 @@ void rs_correct_decode(void *decoder, uint8_t *encoded, size_t encoded_length,
                        uint8_t *msg, size_t pad_length, size_t num_roots);
 
 typedef struct {
+    size_t field_size;
     size_t block_length;
     size_t message_length;
     size_t min_distance;
@@ -30,7 +31,7 @@ typedef struct {
     void *decoder;
 } rs_test;
 
-rs_testbench *rs_testbench_create(size_t block_length, size_t min_distance);
+rs_testbench *rs_testbench_create(size_t field_size, size_t block_length, size_t min_distance);
 void rs_testbench_destroy(rs_testbench *testbench);
 
 typedef struct {

--- a/tests/reed-solomon-fec-interop.c
+++ b/tests/reed-solomon-fec-interop.c
@@ -67,7 +67,7 @@ int main() {
 
     correct_reed_solomon *rs = correct_reed_solomon_create(
         correct_rs_primitive_polynomial_ccsds, 1, 1, min_distance);
-    rs_testbench *testbench = rs_testbench_create(block_length, min_distance);
+    rs_testbench *testbench = rs_testbench_create(256, block_length, min_distance);
 
     pad_length = message_length / 2;
     fec_rs = init_rs_char(8, correct_rs_primitive_polynomial_ccsds, 1, 1, min_distance,
@@ -102,7 +102,7 @@ int main() {
     message_length = block_length - min_distance;
     rs = correct_reed_solomon_create(
         correct_rs_primitive_polynomial_ccsds, 1, 1, min_distance);
-    testbench = rs_testbench_create(block_length, min_distance);
+    testbench = rs_testbench_create(256, block_length, min_distance);
 
     pad_length = message_length / 2;
     fec_rs = init_rs_char(8, correct_rs_primitive_polynomial_ccsds, 1, 1, min_distance,

--- a/tests/reed-solomon-shim-interop.c
+++ b/tests/reed-solomon-shim-interop.c
@@ -67,7 +67,7 @@ int main() {
 
     correct_reed_solomon *rs = correct_reed_solomon_create(
         correct_rs_primitive_polynomial_ccsds, 1, 1, min_distance);
-    rs_testbench *testbench = rs_testbench_create(block_length, min_distance);
+    rs_testbench *testbench = rs_testbench_create(256, block_length, min_distance);
 
     pad_length = message_length / 2;
     fec_rs = init_rs_char(8, correct_rs_primitive_polynomial_ccsds, 1, 1, min_distance,
@@ -102,7 +102,7 @@ int main() {
     message_length = block_length - min_distance;
     rs = correct_reed_solomon_create(
         correct_rs_primitive_polynomial_ccsds, 1, 1, min_distance);
-    testbench = rs_testbench_create(block_length, min_distance);
+    testbench = rs_testbench_create(256, block_length, min_distance);
 
     pad_length = message_length / 2;
     fec_rs = init_rs_char(8, correct_rs_primitive_polynomial_ccsds, 1, 1, min_distance,

--- a/tests/reed-solomon.c
+++ b/tests/reed-solomon.c
@@ -49,7 +49,7 @@ int main() {
 
     correct_reed_solomon *rs = correct_reed_solomon_create(
         correct_rs_primitive_polynomial_ccsds, 1, 1, min_distance);
-    rs_testbench *testbench = rs_testbench_create(block_length, min_distance);
+    rs_testbench *testbench = rs_testbench_create(256, block_length, min_distance);
 
     run_tests(rs, testbench, block_length, message_length / 2, 0, 0, 20000);
     run_tests(rs, testbench, block_length, message_length, 0, 0, 20000);
@@ -73,7 +73,7 @@ int main() {
     message_length = block_length - min_distance;
     rs = correct_reed_solomon_create(
         correct_rs_primitive_polynomial_ccsds, 1, 1, min_distance);
-    testbench = rs_testbench_create(block_length, min_distance);
+    testbench = rs_testbench_create(256, block_length, min_distance);
 
     run_tests(rs, testbench, block_length, message_length / 2, 0, 0, 20000);
     run_tests(rs, testbench, block_length, message_length, 0, 0, 20000);
@@ -97,7 +97,7 @@ int main() {
     message_length = block_length - min_distance;
     rs = correct_reed_solomon_create(
         correct_rs_primitive_polynomial_ccsds, 1, 1, min_distance);
-    testbench = rs_testbench_create(block_length, min_distance);
+    testbench = rs_testbench_create(256, block_length, min_distance);
 
     run_tests(rs, testbench, block_length, message_length / 2, 0, 0, 20000);
     run_tests(rs, testbench, block_length, message_length, 0, 0, 20000);
@@ -121,7 +121,7 @@ int main() {
     message_length = block_length - min_distance;
     rs = correct_reed_solomon_create(
         correct_rs_primitive_polynomial_ccsds, 1, 1, min_distance);
-    testbench = rs_testbench_create(block_length, min_distance);
+    testbench = rs_testbench_create(256, block_length, min_distance);
 
     run_tests(rs, testbench, block_length, message_length / 2, 0, 0, 20000);
     run_tests(rs, testbench, block_length, message_length, 0, 0, 20000);
@@ -140,6 +140,27 @@ int main() {
 
     rs_testbench_destroy(testbench);
     correct_reed_solomon_destroy(rs);
+
+    block_length = 15;
+    min_distance = 2;
+    message_length = block_length - min_distance;
+    rs = correct_reed_solomon_create(0x13, 1, 1, min_distance);
+    testbench = rs_testbench_create(16, block_length, min_distance);
+
+    run_tests(rs, testbench, block_length, message_length / 2, 0, 0, 20000);
+    run_tests(rs, testbench, block_length, message_length, 0, 0, 20000);
+    run_tests(rs, testbench, block_length, message_length / 2, min_distance / 2,
+              0, 20000);
+    run_tests(rs, testbench, block_length, message_length, min_distance / 2, 0,
+              20000);
+    run_tests(rs, testbench, block_length, message_length / 2, 0, min_distance,
+              20000);
+    run_tests(rs, testbench, block_length, message_length, 0, min_distance,
+              20000);
+
+    rs_testbench_destroy(testbench);
+    correct_reed_solomon_destroy(rs);
+
 
     printf("test passed\n");
     return 0;

--- a/tests/rs_tester.c
+++ b/tests/rs_tester.c
@@ -23,13 +23,14 @@ void rs_correct_decode(void *decoder, uint8_t *encoded, size_t encoded_length,
         erasure_locations, erasure_length, msg);
 }
 
-rs_testbench *rs_testbench_create(size_t block_length, size_t min_distance) {
+rs_testbench *rs_testbench_create(size_t field_size, size_t block_length, size_t min_distance) {
     rs_testbench *testbench = calloc(1, sizeof(rs_testbench));
 
     size_t message_length = block_length - min_distance;
     testbench->message_length = message_length;
     testbench->block_length = block_length;
     testbench->min_distance = min_distance;
+    testbench->field_size = field_size;
 
     testbench->msg = calloc(message_length, sizeof(unsigned char));
     testbench->encoded = malloc(block_length * sizeof(uint8_t));
@@ -63,7 +64,7 @@ rs_test_run test_rs_errors(rs_test *test, rs_testbench *testbench, size_t msg_le
     }
 
     for (size_t i = 0; i < msg_length; i++) {
-        testbench->msg[i] = rand() % 256;
+        testbench->msg[i] = rand() % testbench->field_size;
     }
 
     size_t block_length = msg_length + testbench->min_distance;
@@ -81,14 +82,14 @@ rs_test_run test_rs_errors(rs_test *test, rs_testbench *testbench, size_t msg_le
 
     for (unsigned int i = 0; i < num_erasures; i++) {
         int index = testbench->indices[i];
-        uint8_t corruption_mask = (rand() % 255) + 1;
+        uint8_t corruption_mask = (rand() % (testbench->field_size - 1)) + 1;
         testbench->corrupted_encoded[index] ^= corruption_mask;
         testbench->erasure_locations[i] = index;
     }
 
     for (unsigned int i = 0; i < num_errors; i++) {
         int index = testbench->indices[i + num_erasures];
-        uint8_t corruption_mask = (rand() % 255) + 1;
+        uint8_t corruption_mask = (rand() % (testbench->field_size - 1)) + 1;
         testbench->corrupted_encoded[index] ^= corruption_mask;
     }
 


### PR DESCRIPTION
This should make it possible to use RS modes for non GF(2^8). Because many internal types are `uint8_t`, we can't go past 2^8.