### PR TITLE
CMakeLists.txt: fixes for various toolchains

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 2.8)
-project(Correct)
+project(Correct C)
 include(CheckLibraryExists)
 include(CheckIncludeFiles)
-include(CheckCXXSourceCompiles)
+include(CheckCSourceCompiles)
 
 if(MSVC)
 set(LIBM "")
@@ -11,7 +11,7 @@ else(MSVC)
 set(LIBM "m")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -std=c99 -Wpedantic -Wall")
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g3 -O0 -march=native -fsanitize=address")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g3 -O0 -fsanitize=address")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-no_pie,")
 else()
   if("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
@@ -27,7 +27,7 @@ endif(MSVC)
 
 find_library(FEC fec)
 CHECK_LIBRARY_EXISTS(FEC dotprod "" HAVE_LIBFEC)
-check_cxx_source_compiles("
+check_c_source_compiles("
     #include <x86intrin.h>
     int main() {
       __m128i vec;


### PR DESCRIPTION
Hello.  I was going to add libcorrect as a selectable package in buildroot, but I ran into some issues when I ran it against buildroot's tests (which compiles the package using a variety of toolchains with different capabilities/architectures).  To get libcorrect to compile correctly for as many of the toolchains as I could, I did the following:

1. In the Debug build, remove -march=native. Some toolchains may not
support this option and it is not necessary.
2. Specify C as the project language since there is no C++ code. This
allows toolchains lacking C++ support to build the library.
3. Switch check_cxx_source_compiles to check_c_source_compiles, also for
removing dependency on C++.

The one I'm most unsure about is the removal of -march=native.  I don't know why the Debug build would need to specify that, and with my builds it seemed to be fine without.  But maybe there's something I'm not aware of.