### PR TITLE
Make sure the order parameter is smaller than 32

### DIFF
--- a/src/convolutional/convolutional.c
+++ b/src/convolutional/convolutional.c
@@ -5,7 +5,7 @@
 correct_convolutional *_correct_convolutional_init(correct_convolutional *conv,
                                                    size_t rate, size_t order,
                                                    const polynomial_t *poly) {
-    if (order > 8 * sizeof(shift_register_t)) {
+    if (order >= 8 * sizeof(shift_register_t)) {
         // XXX turn this into an error code
         // printf("order must be smaller than 8 * sizeof(shift_register_t)\n");
         return NULL;


### PR DESCRIPTION
The order parameter is later used as an argument for bit shifting, which results in undefined behavior if the argument is bigger than 31.
Found by Coverity (a static code analyzer).