### PR TITLE
bumped cmake_minimum_required to Version 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 project(Correct C)
 include(CheckLibraryExists)
 include(CheckIncludeFiles)


### PR DESCRIPTION
Modern Cmake versions require cmake_mininum_required to be at least Version 3.5